### PR TITLE
fix(xrpl): autofill not validating correctly DeliverMax and Amount

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -8,11 +8,13 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * parseTransactionFlags as a utility function in the xrpl package to streamline transactions flags-to-map conversion
 * Added new MPT transaction definitions (XLS-33)
 * New `MPTAmount` type support for `Payment` and `Clawback` transactions
+* New util `areAmountsEqual` to check if 2 amounts are strictly equal
 
 ### Fixed
 * `TransactionStream` model supports APIv2
 * `TransactionStream` model includes `close_time_iso` field
 * `Ledger` model includes `close_time_iso` field
+* `autofill` function in client not validating amounts correctly
 
 ## 4.0.0 (2024-07-15)
 

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -47,6 +47,7 @@ import type {
   OnEventToListenerMap,
 } from '../models/methods/subscribe'
 import type { SubmittableTransaction } from '../models/transactions'
+import { areAmountsEqual } from '../models/transactions/common'
 import { setTransactionFlagsToNumber } from '../models/utils/flags'
 import {
   ensureClassicAddress,
@@ -699,7 +700,7 @@ class Client extends EventEmitter<EventTypes> {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- ignore type-assertions on the DeliverMax property
       // @ts-expect-error -- DeliverMax property exists only at the RPC level, not at the protocol level
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- This is a valid null check for Amount
-      if (tx.Amount != null && tx.Amount !== tx.DeliverMax) {
+      if (tx.Amount != null && !areAmountsEqual(tx.Amount, tx.DeliverMax)) {
         return Promise.reject(
           new ValidationError(
             'PaymentTransaction: Amount and DeliverMax fields must be identical when both are provided',

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { isValidClassicAddress, isValidXAddress } from 'ripple-address-codec'
 import { TRANSACTION_TYPES } from 'ripple-binary-codec'
 
@@ -166,6 +167,37 @@ export function isAmount(amount: unknown): amount is Amount {
     isIssuedCurrency(amount) ||
     isMPTAmount(amount)
   )
+}
+
+/**
+ * Check if two amounts are equal.
+ *
+ * @param amount1 - The first amount to compare.
+ * @param amount2 - The second amount to compare.
+ * @returns Whether the two amounts are equal.
+ * @throws When the amounts are not valid.
+ */
+export function areAmountsEqual(amount1: unknown, amount2: unknown): boolean {
+  const isAmount1Invalid = !isAmount(amount1)
+  if (isAmount1Invalid || !isAmount(amount2)) {
+    throw new ValidationError(
+      `Amount: invalid field. Expected Amount but received ${JSON.stringify(
+        isAmount1Invalid ? amount1 : amount2,
+      )}`,
+    )
+  }
+
+  if (isString(amount1) && isString(amount2)) {
+    return new BigNumber(amount1).eq(amount2)
+  }
+
+  if (isRecord(amount1) && isRecord(amount2)) {
+    return Object.entries(amount1).every(
+      ([key, value]) => amount2[key] === value,
+    )
+  }
+
+  return false
 }
 
 /**

--- a/packages/xrpl/test/client/autofill.test.ts
+++ b/packages/xrpl/test/client/autofill.test.ts
@@ -6,6 +6,7 @@ import {
   EscrowFinish,
   Payment,
   Transaction,
+  IssuedCurrencyAmount,
 } from '../../src'
 import { ValidationError } from '../../src/errors'
 import rippled from '../fixtures/rippled'
@@ -98,10 +99,45 @@ describe('client.autofill', function () {
     assert.strictEqual('DeliverMax' in txResult, false)
   })
 
+  it('Validate Payment transaction API v2: Payment Transaction: differing DeliverMax and Amount fields using amount objects', async function () {
+    // @ts-expect-error -- DeliverMax is a non-protocol, RPC level field in Payment transactions
+    paymentTx.DeliverMax = {
+      currency: 'USD',
+      value: AMOUNT,
+      issuer: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X',
+    }
+    paymentTx.Amount = {
+      currency: 'USD',
+      value: AMOUNT,
+      issuer: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X',
+    }
+
+    const txResult = await testContext.client.autofill(paymentTx)
+
+    assert.strictEqual((txResult.Amount as IssuedCurrencyAmount).value, AMOUNT)
+    assert.strictEqual('DeliverMax' in txResult, false)
+  })
+
   it('Validate Payment transaction API v2: Payment Transaction: differing DeliverMax and Amount fields', async function () {
     // @ts-expect-error -- DeliverMax is a non-protocol, RPC level field in Payment transactions
     paymentTx.DeliverMax = '6789'
     paymentTx.Amount = '1234'
+
+    await assertRejects(testContext.client.autofill(paymentTx), ValidationError)
+  })
+
+  it('Validate Payment transaction API v2: Payment Transaction: differing DeliverMax and Amount fields using objects', async function () {
+    // @ts-expect-error -- DeliverMax is a non-protocol, RPC level field in Payment transactions
+    paymentTx.DeliverMax = {
+      currency: 'USD',
+      value: '31415',
+      issuer: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X',
+    }
+    paymentTx.Amount = {
+      currency: 'USD',
+      value: '27182',
+      issuer: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X',
+    }
 
     await assertRejects(testContext.client.autofill(paymentTx), ValidationError)
   })


### PR DESCRIPTION
## Autofill function in Client not validating `DeliverMax` and `Amount` correctly

Fixes an issue where the autofill function throws an error when passing amounts as objects.

### Context of Change

In JavaScript, objects are compared by reference, not by their property values. Here's an example to illustrate this behavior:

```
const a = {
  currency: 'USD',
  value: '31415',
  issuer: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X',
};

const b = {
  currency: 'USD',
  value: '31415',
  issuer: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X',
};

console.log(a === b); // Output: false
```
Because objects are compared by reference, even identical objects like a and b are considered different. This was causing incorrect validation in the autofill function when dealing with amounts represented as objects.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

I have added tests to verify that the bug is resolved.

